### PR TITLE
Support usage in a no_std + alloc environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bit-set"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Alexis Beingessner <a.beingessner@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A set of bits"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ readme = "README.md"
 [dev-dependencies]
 rand = "0.3"
 
-[dependencies]
-bit-vec = "0.4"
+[dependencies.bit-vec]
+version = "0.5.0"
+default-features = false
 
 [features]
-nightly = []
+default = ["std"]
+nightly = ["bit-vec/nightly"]
+std = ["bit-vec/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,17 +47,23 @@
 //! assert!(bv[3]);
 //! ```
 
+#![no_std]
+
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 #[cfg(all(test, feature = "nightly"))] extern crate test;
 #[cfg(all(test, feature = "nightly"))] extern crate rand;
 extern crate bit_vec;
 
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
 use bit_vec::{BitVec, Blocks, BitBlock};
-use std::cmp::Ordering;
-use std::cmp;
-use std::fmt;
-use std::hash;
-use std::iter::{self, Chain, Enumerate, FromIterator, Repeat, Skip, Take};
+use core::cmp::Ordering;
+use core::cmp;
+use core::fmt;
+use core::hash;
+use core::iter::{self, Chain, Enumerate, FromIterator, Repeat, Skip, Take};
 
 type MatchWords<'a, B> = Chain<Enumerate<Blocks<'a, B>>, Skip<Take<Enumerate<Repeat<B>>>>>;
 
@@ -941,6 +947,7 @@ mod tests {
     use std::cmp::Ordering::{Equal, Greater, Less};
     use super::BitSet;
     use bit_vec::BitVec;
+    use std::vec::Vec;
 
     #[test]
     fn test_bit_set_show() {


### PR DESCRIPTION
Depends on https://github.com/contain-rs/bit-vec/pull/49 landing, and has a similar purpose -- to allow the use of bit-set in environments with no std library, but access to `alloc`.

This should be a backwards compatible change, which really only makes a difference when users intentionally opt-out of the new default feature flag named "std".