### PR TITLE
Rename len() to count() to reflect its performance implication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bit-set"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Alexis Beingessner <a.beingessner@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A set of bits"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -758,8 +758,17 @@ impl<B: BitBlock> BitSet<B> {
     ///
     /// Note that this function scans the set to calculate the number.
     #[inline]
-    pub fn len(&self) -> usize {
+    pub fn count(&self) -> usize {
         self.bit_vec.blocks().fold(0, |acc, n| acc + n.count_ones())
+    }
+
+    /// Counts the number of set bits in this set.
+    ///
+    /// Note that this function scans the set to calculate the number.
+    #[inline]
+    #[deprecated = "use BitVec::count() instead"]
+    pub fn len(&self) -> usize {
+        self.count()
     }
 
     /// Returns whether there are no bits set in this set
@@ -1383,31 +1392,31 @@ mod tests {
         // and this would end up actually growing the array in a way
         // that (safely corrupted the state).
         let mut a = BitSet::new();
-        assert_eq!(a.len(), 0);
+        assert_eq!(a.count(), 0);
         assert_eq!(a.capacity(), 0);
         a.shrink_to_fit();
-        assert_eq!(a.len(), 0);
+        assert_eq!(a.count(), 0);
         assert_eq!(a.capacity(), 0);
         assert!(!a.contains(1));
         a.insert(3);
         assert!(a.contains(3));
-        assert_eq!(a.len(), 1);
+        assert_eq!(a.count(), 1);
         assert!(a.capacity() > 0);
         a.shrink_to_fit();
         assert!(a.contains(3));
-        assert_eq!(a.len(), 1);
+        assert_eq!(a.count(), 1);
         assert!(a.capacity() > 0);
     }
 
     #[test]
     fn test_bit_set_shrink_to_fit() {
         let mut a = BitSet::new();
-        assert_eq!(a.len(), 0);
+        assert_eq!(a.count(), 0);
         assert_eq!(a.capacity(), 0);
         a.insert(259);
         a.insert(98);
         a.insert(3);
-        assert_eq!(a.len(), 3);
+        assert_eq!(a.count(), 3);
         assert!(a.capacity() > 0);
         assert!(!a.contains(1));
         assert!(a.contains(259));
@@ -1419,7 +1428,7 @@ mod tests {
         assert!(a.contains(259));
         assert!(a.contains(98));
         assert!(a.contains(3));
-        assert_eq!(a.len(), 3);
+        assert_eq!(a.count(), 3);
         assert!(a.capacity() > 0);
 
         let old_cap = a.capacity();
@@ -1430,12 +1439,12 @@ mod tests {
         assert!(!a.contains(259));
         assert!(a.contains(98));
         assert!(a.contains(3));
-        assert_eq!(a.len(), 2);
+        assert_eq!(a.count(), 2);
 
         let old_cap2 = a.capacity();
         a.clear();
         assert_eq!(a.capacity(), old_cap2);
-        assert_eq!(a.len(), 0);
+        assert_eq!(a.count(), 0);
         assert!(!a.contains(1));
         assert!(!a.contains(259));
         assert!(!a.contains(98));
@@ -1443,7 +1452,7 @@ mod tests {
 
         a.insert(512);
         assert!(a.capacity() > 0);
-        assert_eq!(a.len(), 1);
+        assert_eq!(a.count(), 1);
         assert!(a.contains(512));
         assert!(!a.contains(1));
         assert!(!a.contains(259));
@@ -1453,7 +1462,7 @@ mod tests {
         a.remove(512);
         a.shrink_to_fit();
         assert_eq!(a.capacity(), 0);
-        assert_eq!(a.len(), 0);
+        assert_eq!(a.count(), 0);
         assert!(!a.contains(512));
         assert!(!a.contains(1));
         assert!(!a.contains(259));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -650,8 +650,8 @@ impl<B: BitBlock> BitSet<B> {
     ///
     /// a.append(&mut b);
     ///
-    /// assert_eq!(a.len(), 4);
-    /// assert_eq!(b.len(), 0);
+    /// assert_eq!(a.count(), 4);
+    /// assert_eq!(b.count(), 0);
     /// assert_eq!(a, BitSet::from_bytes(&[0b01110010]));
     /// ```
     pub fn append(&mut self, other: &mut Self) {
@@ -675,8 +675,8 @@ impl<B: BitBlock> BitSet<B> {
     ///
     /// let b = a.split_off(3);
     ///
-    /// assert_eq!(a.len(), 2);
-    /// assert_eq!(b.len(), 2);
+    /// assert_eq!(a.count(), 2);
+    /// assert_eq!(b.count(), 2);
     /// assert_eq!(a, BitSet::from_bytes(&[0b01100000]));
     /// assert_eq!(b, BitSet::from_bytes(&[0b00010010]));
     /// ```
@@ -711,9 +711,11 @@ impl<B: BitBlock> BitSet<B> {
     }
 */
 
-    /// Returns the number of set bits in this set.
+    /// Counts the number of set bits in this set.
+    ///
+    /// Note that this function scans the set to calculate the number.
     #[inline]
-    pub fn len(&self) -> usize  {
+    pub fn count(&self) -> usize  {
         self.bit_vec.blocks().fold(0, |acc, n| acc + n.count_ones() as usize)
     }
 
@@ -1024,7 +1026,7 @@ mod tests {
         assert!(b.insert(400));
         assert!(!b.insert(400));
         assert!(b.contains(400));
-        assert_eq!(b.len(), 3);
+        assert_eq!(b.count(), 3);
     }
 
     #[test]
@@ -1176,8 +1178,8 @@ mod tests {
         let c = a.clone();
         a.union_with(&b);
         b.union_with(&c);
-        assert_eq!(a.len(), 4);
-        assert_eq!(b.len(), 4);
+        assert_eq!(a.count(), 4);
+        assert_eq!(b.count(), 4);
     }
 
     #[test]
@@ -1206,8 +1208,8 @@ mod tests {
         let c = a.clone();
         a.intersect_with(&b);
         b.intersect_with(&c);
-        assert_eq!(a.len(), 2);
-        assert_eq!(b.len(), 2);
+        assert_eq!(a.count(), 2);
+        assert_eq!(b.count(), 2);
     }
 
     #[test]
@@ -1230,8 +1232,8 @@ mod tests {
         let c = a.clone();
         a.difference_with(&b);
         b.difference_with(&c);
-        assert_eq!(a.len(), 1);
-        assert_eq!(b.len(), 1);
+        assert_eq!(a.count(), 1);
+        assert_eq!(b.count(), 1);
     }
 
     #[test]
@@ -1259,8 +1261,8 @@ mod tests {
         let c = a.clone();
         a.symmetric_difference_with(&b);
         b.symmetric_difference_with(&c);
-        assert_eq!(a.len(), 2);
-        assert_eq!(b.len(), 2);
+        assert_eq!(a.count(), 2);
+        assert_eq!(b.count(), 2);
     }
 
     #[test]
@@ -1339,8 +1341,8 @@ mod tests {
 
         a.append(&mut b);
 
-        assert_eq!(a.len(), 4);
-        assert_eq!(b.len(), 0);
+        assert_eq!(a.count(), 4);
+        assert_eq!(b.count(), 0);
         assert!(b.capacity() >= 6);
 
         assert_eq!(a, BitSet::from_bytes(&[0b01110010]));
@@ -1354,8 +1356,8 @@ mod tests {
 
         let b = a.split_off(0);
 
-        assert_eq!(a.len(), 0);
-        assert_eq!(b.len(), 21);
+        assert_eq!(a.count(), 0);
+        assert_eq!(b.count(), 21);
 
         assert_eq!(b, BitSet::from_bytes(&[0b10100000, 0b00010010, 0b10010010,
                                            0b00110011, 0b01101011, 0b10101101]);
@@ -1366,8 +1368,8 @@ mod tests {
 
         let b = a.split_off(50);
 
-        assert_eq!(a.len(), 21);
-        assert_eq!(b.len(), 0);
+        assert_eq!(a.count(), 21);
+        assert_eq!(b.count(), 0);
 
         assert_eq!(a, BitSet::from_bytes(&[0b10100000, 0b00010010, 0b10010010,
                                            0b00110011, 0b01101011, 0b10101101]));
@@ -1378,8 +1380,8 @@ mod tests {
 
         let b = a.split_off(34);
 
-        assert_eq!(a.len(), 12);
-        assert_eq!(b.len(), 9);
+        assert_eq!(a.count(), 12);
+        assert_eq!(b.count(), 9);
 
         assert_eq!(a, BitSet::from_bytes(&[0b10100000, 0b00010010, 0b10010010,
                                            0b00110011, 0b01000000]));


### PR DESCRIPTION
In Rust, `len()` (as a noun) is commonly used to refer to something which can be figured out in constant time, usually reading a field or so, while the function here apparently is not just reading some field, but instead iterating through the internal vector and add up the number of set bits. For non-constant time operations, it should be preferred to use a verb name to indicate that it may not be cheap. I think the convention is to use `count()` for this scenario.

I also bumped the minor version as renaming a function is a breaking change. Let me know if you prefer keeping `len()` but having it deprecated so that we don't do breaking change for this.