### PR TITLE
Remove reference of non-existent nightly feature in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - rust: stable
     - rust: nightly
-      env: FEATURES="--features nightly"
 script:
     - cargo build $FEATURES
     - cargo test $FEATURES


### PR DESCRIPTION
The `nightly` feature was removed in 90ad34c4cb15d15c310f5926c9e5d1b76617e699 but the travis config was not updated accordingly, causing CI to fail on the nightly task.