### PR TITLE
Fix BlockIter::size_hint upper bound

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -917,7 +917,7 @@ where
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self.tail.size_hint() {
-            (_, Some(h)) => (0, Some(1 + h * B::bits())),
+            (_, Some(h)) => (0, Some((1 + h) * B::bits())),
             _ => (0, None),
         }
     }


### PR DESCRIPTION
This pull request fixes an issue with `BlockIter` possibly returning a too low upper bound on its number of elements.

The current block (`self.head`) can contribute up to `B::bits()` elements, not just one.