### PR TITLE
chore: bump deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["data-structures", "bitset"]
 readme = "README.md"
 
 [dev-dependencies]
-rand = "0.3"
+rand = "0.8"
 
 [dependencies.bit-vec]
-version = "0.6.1"
+version = "0.7.0"
 default-features = false
 
 [features]


### PR DESCRIPTION
I want to update the dependencies and release a new version.

```

error[E0308]: mismatched types
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/deno_core-0.272.0/arena/raw_arena.rs:290:43
    |
290 |         for alloc in BitSet::from_bit_vec(vacant).into_iter() {
    |                      -------------------- ^^^^^^ expected `bit_vec::BitVec`, found `BitVec`
    |                      |
    |                      arguments to this function are incorrect
    |
    = note: `BitVec` and `bit_vec::BitVec` have similar names, but are actually distinct types
note: `BitVec` is defined in crate `bit_vec`
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bit-vec-0.7.0/src/lib.rs:245:1
    |
245 | pub struct BitVec<B = u32> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
note: `bit_vec::BitVec` is defined in crate `bit_vec`
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bit-vec-0.6.3/src/lib.rs:212:1
    |
212 | pub struct BitVec<B=u32> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `bit_vec` are being used?
note: associated function defined here
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bit-set-0.5.3/src/lib.rs:238:12
    |
238 |     pub fn from_bit_vec(bit_vec: BitVec) -> Self {
    |            ^^^^^^^^^^^^
```


cc @Gankra @pczarn 