### PR TITLE
Crate metadata: Link to docs.rs for docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "A set of bits"
 repository = "https://github.com/contain-rs/bit-set"
 homepage = "https://github.com/contain-rs/bit-set"
-documentation = "https://contain-rs.github.io/bit-set/bit_set"
+documentation = "https://docs.rs/bit-set/"
 keywords = ["data-structures", "bitset"]
 readme = "README.md"
 


### PR DESCRIPTION
This is where the docs are linked to in the README and the ones on GitHub Pages aren't up to date.