### PR TITLE
Mention BitSet instead of BitVec in deprecation notice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -867,7 +867,7 @@ impl<B: BitBlock> BitSet<B> {
     ///
     /// Note that this function scans the set to calculate the number.
     #[inline]
-    #[deprecated = "use BitVec::count() instead"]
+    #[deprecated = "use BitSet::count() instead"]
     pub fn len(&self) -> usize {
         self.count()
     }


### PR DESCRIPTION
This is for the BitSet struct and the reference to the underlying implementation is confusing.